### PR TITLE
Laravel7 compatibilty / Fingegrained Route/RouteGroup Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,14 @@ Installation
 1. Install `imi/laravel-transsid` via composer.
 2. In your `config/app.php` at `providers` replace 
     `'Illuminate\Session\SessionServiceProvider'` with `'iMi\LaravelTransSid\SessionServiceProvider'` 
-3. add `'iMi\LaravelTransSid\UrlServiceProvider'` at the end of the providers array
+3. Add `'iMi\LaravelTransSid\UrlServiceProvider'` at the end of the providers array
+4. In your `app/Http/Kernel.php` add `'urlsession' => iMi\LaravelTransSid\UrlSession::class`
+
+
+Usage
+-----
+
+To use SessionIDs in URLs add the middleware `urlsession` to your route or routegroup.
 
 URLs generated with Laravel's URL function (for example `URL::to()`) will now have a session ID appended. If you would like to generate URLs without a session ID, add a `NO_ADD_SID` parameter:
 

--- a/src/SessionServiceProvider.php
+++ b/src/SessionServiceProvider.php
@@ -13,7 +13,7 @@ class SessionServiceProvider extends \Illuminate\Session\SessionServiceProvider
         $this->registerSessionManager();
 
         $this->registerSessionDriver();
-
+ 
         $this->app->singleton(StartSession::class, function () {
             return new StartSessionMiddleware($this->app->make(SessionManager::class), function () {
                 return $this->app->make(CacheFactory::class);

--- a/src/SessionServiceProvider.php
+++ b/src/SessionServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace iMi\LaravelTransSid;
 
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\Session\SessionManager;
+
 class SessionServiceProvider extends \Illuminate\Session\SessionServiceProvider
 {
     public function register()
@@ -10,6 +14,10 @@ class SessionServiceProvider extends \Illuminate\Session\SessionServiceProvider
 
         $this->registerSessionDriver();
 
-        $this->app->singleton('Illuminate\Session\Middleware\StartSession', 'iMi\LaravelTransSid\StartSessionMiddleware');
+        $this->app->singleton(StartSessionMiddleware::class, function () {
+            return new StartSessionMiddleware($this->app->make(SessionManager::class), function () {
+                return $this->app->make(CacheFactory::class);
+            });
+        });
     }
 }

--- a/src/SessionServiceProvider.php
+++ b/src/SessionServiceProvider.php
@@ -13,7 +13,7 @@ class SessionServiceProvider extends \Illuminate\Session\SessionServiceProvider
         $this->registerSessionManager();
 
         $this->registerSessionDriver();
- 
+
         $this->app->singleton(StartSession::class, function () {
             return new StartSessionMiddleware($this->app->make(SessionManager::class), function () {
                 return $this->app->make(CacheFactory::class);

--- a/src/SessionServiceProvider.php
+++ b/src/SessionServiceProvider.php
@@ -14,7 +14,7 @@ class SessionServiceProvider extends \Illuminate\Session\SessionServiceProvider
 
         $this->registerSessionDriver();
 
-        $this->app->singleton(StartSessionMiddleware::class, function () {
+        $this->app->singleton(StartSession::class, function () {
             return new StartSessionMiddleware($this->app->make(SessionManager::class), function () {
                 return $this->app->make(CacheFactory::class);
             });

--- a/src/StartSessionMiddleware.php
+++ b/src/StartSessionMiddleware.php
@@ -16,8 +16,8 @@ class StartSessionMiddleware extends \Illuminate\Session\Middleware\StartSession
      */
     protected function lockToUser($session, $request)
     {
-        $session->set(self::LOCKED_FIELD, [
-            'ip' => $request->getClientIp(),
+        $session->put(self::LOCKED_FIELD, [
+            'ip'    => $request->getClientIp(),
             'agent' => md5($request->server('HTTP_USER_AGENT'))
         ]);
     }
@@ -36,6 +36,12 @@ class StartSessionMiddleware extends \Illuminate\Session\Middleware\StartSession
             || $locked['agent'] != md5($request->server('HTTP_USER_AGENT')));
     }
 
+    /**
+     * Overwritten from parent class.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return \Illuminate\Contracts\Session\Session|mixed
+     */
     public function getSession(\Illuminate\Http\Request $request)
     {
         $session = $this->manager->driver();
@@ -45,6 +51,7 @@ class StartSessionMiddleware extends \Illuminate\Session\Middleware\StartSession
         if (!$session->has(self::LOCKED_FIELD)) {
             $this->lockToUser($session, $request);
         } else {
+
             // validate session against store IP and user agent hash
             if (!$this->validate($session, $request)) {
                 $session->setId(null); // refresh ID
@@ -52,7 +59,6 @@ class StartSessionMiddleware extends \Illuminate\Session\Middleware\StartSession
                 $this->lockToUser($session, $request);
             }
         }
-
         return $session;
     }
 }

--- a/src/StartSessionMiddleware.php
+++ b/src/StartSessionMiddleware.php
@@ -42,18 +42,15 @@ class StartSessionMiddleware extends \Illuminate\Session\Middleware\StartSession
      * @param \Illuminate\Http\Request $request
      * @return \Illuminate\Contracts\Session\Session|mixed
      */
-  /*  public function getSession(\Illuminate\Http\Request $request)
+    public function getSession(\Illuminate\Http\Request $request)
     {
         $session = $this->manager->driver();
         $session->setId($request->input($session->getName()));
-
-
-
         $session->start();
+
         if (!$session->has(self::LOCKED_FIELD)) {
             $this->lockToUser($session, $request);
         } else {
-
             // validate session against store IP and user agent hash
             if (!$this->validate($session, $request)) {
                 $session->setId(null); // refresh ID
@@ -62,5 +59,5 @@ class StartSessionMiddleware extends \Illuminate\Session\Middleware\StartSession
             }
         }
         return $session;
-    }*/ 
+    }
 }

--- a/src/StartSessionMiddleware.php
+++ b/src/StartSessionMiddleware.php
@@ -42,10 +42,12 @@ class StartSessionMiddleware extends \Illuminate\Session\Middleware\StartSession
      * @param \Illuminate\Http\Request $request
      * @return \Illuminate\Contracts\Session\Session|mixed
      */
-    public function getSession(\Illuminate\Http\Request $request)
+  /*  public function getSession(\Illuminate\Http\Request $request)
     {
         $session = $this->manager->driver();
         $session->setId($request->input($session->getName()));
+
+
 
         $session->start();
         if (!$session->has(self::LOCKED_FIELD)) {
@@ -60,5 +62,5 @@ class StartSessionMiddleware extends \Illuminate\Session\Middleware\StartSession
             }
         }
         return $session;
-    }
+    }*/ 
 }

--- a/src/UrlGeneratorService.php
+++ b/src/UrlGeneratorService.php
@@ -1,34 +1,37 @@
 <?php
 
-
 namespace iMi\LaravelTransSid;
 
 use Illuminate\Routing\UrlGenerator;
+use Illuminate\Support\Facades\Route;
 
 class UrlGeneratorService extends UrlGenerator
 {
-    public function addSid($url) {
-        if (strpos($url, \Config::get('session.cookie')) !== false) {
-            return $url;
+    public function addSid($url)
+    {
+        // Only apply transsid to routes/routegroups with the urlsession middleware.
+        if (in_array('urlsession', Route::current()->computedMiddleware)) {
+            if (strpos($url, \Config::get('session.cookie')) !== false) {
+                return $url;
+            }
+            $sep = (strpos($url, '?') !== false) ? '&' : '?';
+            $url .= $sep . \Config::get('session.cookie') . '=' . \Session::getId();
         }
-        $sep = (strpos($url, '?') !== false) ? '&' : '?';
-        $url .= $sep . \Config::get('session.cookie') . '=' . \Session::getId();
         return $url;
-
     }
+
     public function to($path, $extra = array(), $secure = null)
     {
         if (isset($extra['NO_ADD_SID'])) {
             unset($extra['NO_ADD_SID']);
             return parent::to($path, $extra, $secure);
         }
-
         $url = parent::to($path, $extra, $secure);
         $url = $this->addSid($url);
         return $url;
     }
 
-    protected function toRoute($route, $parameters, $absolute)
+    public function toRoute($route, $parameters, $absolute)
     {
         if (isset($parameters['NO_ADD_SID'])) {
             unset($parameters['NO_ADD_SID']);
@@ -44,7 +47,6 @@ class UrlGeneratorService extends UrlGenerator
     public function previous($fallback = false)
     {
         $url = parent::previous($fallback);
-        $url = parent::previous();
         $url = $this->addSid($url);
         return $url;
     }

--- a/src/UrlServiceProvider.php
+++ b/src/UrlServiceProvider.php
@@ -24,12 +24,9 @@ class UrlServiceProvider extends ServiceProvider
             $this->app->instance('routes', $routes);
 
             $url = new UrlGeneratorService(
-                $routes, $app->rebinding(
-                'request', function ($app, $request) {
+                $routes, $app->rebinding('request', function ($app, $request) {
                 $app['url']->setRequest($request);
-            }
-            )
-            );
+            }));
 
             $url->setSessionResolver(function () {
                 return $this->app['session'];

--- a/src/UrlSession.php
+++ b/src/UrlSession.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace iMi\LaravelTransSid;
+
+use Closure;
+
+class UrlSession
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        ini_set('session.use_trans_sid', 1);
+        ini_set('session.use_cookies', 0);
+        ini_set('session.use_only_cookies', 0);
+        return $next($request);
+    }
+}


### PR DESCRIPTION
The package now works with laravel 7 and offers the posibility to define for which routes or routegroups it should apply. This is done configuring the middleware `urlsession`.