### PR TITLE
deal with empty result

### DIFF
--- a/src/UrlGeneratorService.php
+++ b/src/UrlGeneratorService.php
@@ -14,7 +14,7 @@ class UrlGeneratorService extends UrlGenerator
         }
 
         // Get the current query string and parameters
-        $queryString = parse_url($url, PHP_URL_QUERY);
+        $queryString = parse_url($url, PHP_URL_QUERY) ?? '';
         parse_str($queryString, $queryParameters);
 
         // Add the session to the query string if needed


### PR DESCRIPTION
`parse_url` can generate empty results, but `parse_str` needs a string as its first parameter