### PR TITLE
Don't add "?" to URL if $queryParameters is empty

### DIFF
--- a/src/UrlGeneratorService.php
+++ b/src/UrlGeneratorService.php
@@ -26,7 +26,9 @@ class UrlGeneratorService extends UrlGenerator
 
         // Rebuild the URL
         $url = str_replace('?' . $queryString, '', $url);
-        $url .= '?' . http_build_query($queryParameters);
+        if(!empty($queryParameters)) {
+            $url .= '?' . http_build_query($queryParameters);
+        }
 
         return $url;
     }


### PR DESCRIPTION
When building a URL, with `NO_ADD_SID`, it could happen that there are no other query parameters. In this case, we can leave `$url` as it is.