### PR TITLE
don't expose sessionID to other domains

### DIFF
--- a/src/UrlGeneratorService.php
+++ b/src/UrlGeneratorService.php
@@ -13,6 +13,11 @@ class UrlGeneratorService extends UrlGenerator
             return $url;
         }
 
+        // Don't expose sessionID to other Domains
+        if(parse_url($url, PHP_URL_HOST) != parse_url(\Config::get('app.url'))) {
+            return $url;
+        }
+
         // Get the current query string and parameters
         $queryString = parse_url($url, PHP_URL_QUERY) ?? '';
         parse_str($queryString, $queryParameters);


### PR DESCRIPTION
When using the `redirect()` helper, Laravel will internally use the `to()` method in `UrlGeneratorService`. In this case we can't set the `NO_ADD_SID` flag. But since there is no reason at all to leak our session ID to another party, we should just return the URL.