### PR TITLE
Bugfix: both parse_url() use the same flags

### DIFF
--- a/src/UrlGeneratorService.php
+++ b/src/UrlGeneratorService.php
@@ -14,7 +14,7 @@ class UrlGeneratorService extends UrlGenerator
         }
 
         // Don't expose sessionID to other Domains
-        if(parse_url($url, PHP_URL_HOST) != parse_url(\Config::get('app.url'))) {
+        if(parse_url($url, PHP_URL_HOST) != parse_url(\Config::get('app.url'), PHP_URL_HOST)) {
             return $url;
         }
 


### PR DESCRIPTION
Somehow I messed up the commit before this one and removed `, PHP_URL_HOST` from the second `parse_url()`. 

This way, every call to `addSid()` returned the unchanged URL and disabled the whole package, whoops :dizzy_face: