### PR TITLE
leave urls without host alone

### DIFF
--- a/src/UrlGeneratorService.php
+++ b/src/UrlGeneratorService.php
@@ -14,7 +14,8 @@ class UrlGeneratorService extends UrlGenerator
         }
 
         // Don't expose sessionID to other Domains
-        if(parse_url($url, PHP_URL_HOST) != parse_url(\Config::get('app.url'), PHP_URL_HOST)) {
+        $host = parse_url($url, PHP_URL_HOST);
+        if($host && $host != parse_url(\Config::get('app.url'), PHP_URL_HOST)) {
             return $url;
         }
 


### PR DESCRIPTION
Livewire generates URLs like '/livewire/update'. In this case, we need to skip this check.